### PR TITLE
fix: update external article URL and remove autostart code

### DIFF
--- a/app/src/routes/main/stores/index.svelte.ts
+++ b/app/src/routes/main/stores/index.svelte.ts
@@ -1,7 +1,3 @@
-import {
-	enable as enableAutoStart,
-	isEnabled as isEnableAutoStart
-} from '@tauri-apps/plugin-autostart';
 import type { Article } from '$lib/types/article';
 
 import {
@@ -153,13 +149,6 @@ function createStore() {
 					scheduleUpdate();
 				}
 			});
-		});
-
-		// 设置自启动
-		// TODO：根据用户设置自动设置自启动，默认自启动。
-		isEnableAutoStart().then((enable) => {
-			console.log(`isEnableAutoStart...${enable}`);
-			if (!enable) enableAutoStart().then(() => console.log('enableAutoStart completed'));
 		});
 	});
 

--- a/app/src/routes/settings/+page.svelte
+++ b/app/src/routes/settings/+page.svelte
@@ -224,7 +224,7 @@
 
 	// 线上使用说明
 	function openGLMGuide() {
-		featuresApi.open_article_external('https://maas.aminer.cn/');
+		featuresApi.open_article_external('https://bigmodel.cn');
 	}
 
 	// 内存AppConfig更新后的衍生执行代码

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -41,5 +41,7 @@ export default defineConfig(async () => ({
 			// 3. tell vite to ignore watching `src-tauri`
 			ignored: ['**/src-tauri/**']
 		}
-	}
+	},
+
+	optimizeDeps: { exclude: ['fsevents'] }
 }));


### PR DESCRIPTION
- Fix the logical bug that can cause the enable-autostart always run at startup
- Change GLM guide URL from maas.aminer.cn to bigmodel.cn
- Add fsevents exclusion to optimizeDeps in vite config