### PR TITLE
refactor(daemon): remove redundant cold start delay in feeds update loop

### DIFF
--- a/app/src-tauri/src/daemon/feeds_update.rs
+++ b/app/src-tauri/src/daemon/feeds_update.rs
@@ -43,11 +43,10 @@ async fn schedule_loop<R: Runtime>(
         false => 60 * 60 * 3,
     };
     let mut interval = time::interval(Duration::from_secs(update_interval));
-    let mut cold_start_delay = time::interval(Duration::from_secs(360));
 
     // 定时任务
     loop {
-        cold_start_delay.tick().await;
+        interval.tick().await;
         info!("scheduled feeds update begin");
         let feeds_packages = features.get_feeds_packages().await;
         for feed_package in feeds_packages {
@@ -65,6 +64,5 @@ async fn schedule_loop<R: Runtime>(
             }
         }
         info!("scheduled feeds update end");
-        interval.tick().await;
     }
 }


### PR DESCRIPTION
The cold start delay interval was unnecessary since we're already using the main update interval. This simplifies the loop logic while maintaining the same functionality.