### PR TITLE
refactor(lib): move schedule update outside daemon check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ node_modules
 .env
 .env.*
 !.env.example
+.vercel

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -53,15 +53,14 @@ pub fn run() {
             }
 
             let is_daemon = env::is_daemon();
-            if is_daemon {
-                let state: State<'_, Arc<HybridRuntimeState>> = app.state();
-                let state_clone = Arc::clone(&state);
-                launch_feeds_schedule_update(handle, state_clone).unwrap();
-            } else {
+            if !is_daemon {
                 if let Some(window) = app.get_window(WINDOW_MAIN_LABEL) {
                     window.show().unwrap();
                 }
             }
+            let state: State<'_, Arc<HybridRuntimeState>> = app.state();
+            let state_clone = Arc::clone(&state);
+            launch_feeds_schedule_update(handle, state_clone).unwrap();
             Ok(())
         })
         .run(tauri::generate_context!())


### PR DESCRIPTION
The schedule update should run regardless of daemon mode to ensure feed updates happen consistently. This change moves the launch_feeds_schedule_update call outside the conditional block while maintaining the window show logic for non-daemon mode.